### PR TITLE
Update build_far2l.sh - patch for if_tunnel.h

### DIFF
--- a/build_far2l.sh
+++ b/build_far2l.sh
@@ -17,6 +17,11 @@ if [[ "$PLUGINS_EXTRA" == "true" ]]; then
       find . -mindepth 1 -name 'src' -prune -o -exec rm -rf {} + && \
       mv src/* . && rm -rf src )
     echo "add_subdirectory($plug)" >> CMakeLists.txt
+    if [[ "$plug" == "netcfgplugin" ]]; then
+      # patch if_tunnel.h, add ip.h before
+      echo 'patch if_tunnel.h, add ip.h before'
+      sed -ibak 's!#include <linux/if_tunnel.h>!#include <linux/ip.h>\n#include <linux/if_tunnel.h>!' netcfgplugin/common/netlink.h
+    fi
   done
 fi
 if [[ "$PLUGINS" == "false" ]]; then


### PR DESCRIPTION
# fix error
/usr/include/linux/if_tunnel.h:52:33: error: field 'iph' has incomplete type 'iphdr'
   52 |         struct iphdr            iph;
FAILED: far2l-netcfgplugin/CMakeFiles/netcfg.dir/netif/netifs.cpp.o

 # patch if_tunnel.h, add ip.h before